### PR TITLE
Add continuous integration for QA

### DIFF
--- a/.build.yml
+++ b/.build.yml
@@ -7,3 +7,6 @@ tasks:
   - build: |
       cd recipe-book-backend
       cargo build --verbose
+  - test: |
+      cd recipe-book-backend
+      cargo test --verbose

--- a/.build.yml
+++ b/.build.yml
@@ -1,0 +1,9 @@
+image: archlinux
+packages:
+  - rustup
+sources:
+  - https://github.com/Austin-Ray/recipe-book-backend
+tasks:
+  - build: |
+      cd recipe-book-backend
+      cargo build --verbose

--- a/.build.yml
+++ b/.build.yml
@@ -33,3 +33,6 @@ tasks:
         export VCS_PULL_REQUEST="$GITHUB_PR_NUMBER"
         bash <(curl -s https://codecov.io/bash) -f lcov.info
       fi
+  - qa: |
+      cd recipe-book-backend
+      cargo clippy -- -D warnings

--- a/.build.yml
+++ b/.build.yml
@@ -3,10 +3,33 @@ packages:
   - rustup
 sources:
   - https://github.com/Austin-Ray/recipe-book-backend
+secrets:
+  - 05c3a841-4367-4f6f-bd8a-79a4659554e7
+environment:
+  RUSTFLAGS: -Zinstrument-coverage
+  LLVM_PROFILE_FILE: "your_name-%p-%m.profraw"
 tasks:
+  - setup: |
+      cd recipe-book-backend
+      curl -L https://github.com/mozilla/grcov/releases/latest/download/grcov-linux-x86_64.tar.bz2 | tar jxf -
+      rustup default nightly
+      rustup component add llvm-tools-preview
   - build: |
       cd recipe-book-backend
       cargo build --verbose
   - test: |
       cd recipe-book-backend
       cargo test --verbose
+      if [ -f ~/.code-cov ];
+      then
+        set +x
+        source ~/.code-cov
+        set -x
+        ./grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" -o lcov.info
+        export CI_BUILD_URL="$JOB_URL"
+        export CI_BUILD_ID="$JOB_ID"
+        export CI_JOB_ID="$JOB_ID"
+        export VCS_BRANCH_NAME="${GITHUB_REF#refs/heads/}"
+        export VCS_PULL_REQUEST="$GITHUB_PR_NUMBER"
+        bash <(curl -s https://codecov.io/bash) -f lcov.info
+      fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 *.db
+lcov.info

--- a/src/main.rs
+++ b/src/main.rs
@@ -158,7 +158,7 @@ async fn edit(recipe_json: web::Json<Recipe>, db: web::Data<Pool>) -> Result<Htt
 
     let recipe: Recipe = recipe_json.into_inner();
 
-    if let None = &recipe.id {
+    if recipe.id.is_none() {
         return Ok(HttpResponse::BadRequest().body("Missing recipe ID"));
     }
 
@@ -176,7 +176,7 @@ fn load_steps(conn: &SqliteConn, recipe_id: u32) -> rusqlite::Result<Vec<String>
     let mut stmt = conn.prepare("SELECT text FROM steps WHERE recipe_id = ?")?;
 
     let steps: Vec<String> = stmt
-        .query_map(params![recipe_id], |row| Ok(row.get(0)?))?
+        .query_map(params![recipe_id], |row| row.get(0))?
         .filter_map(|x| x.ok())
         .collect();
 


### PR DESCRIPTION
This PR configures continuous integration via builds.sr.ht to build every commit/PR and enables the following QA steps:
 - Unit test
 - Test coverage reporting to codecov.io
 - Static analysis via clippy (warnings treated as errors.)